### PR TITLE
특정 포스트 모든 댓글 조회 구현

### DIFF
--- a/src/main/java/com/tripmate/tripmate/post/api/CommentController.java
+++ b/src/main/java/com/tripmate/tripmate/post/api/CommentController.java
@@ -3,6 +3,7 @@ package com.tripmate.tripmate.post.api;
 import com.tripmate.tripmate.common.ResponseForm;
 import com.tripmate.tripmate.post.dto.request.CommentRequest;
 import com.tripmate.tripmate.post.dto.response.CommentResponse;
+import com.tripmate.tripmate.post.dto.response.CommentPageResponse;
 import com.tripmate.tripmate.post.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,11 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
+
+    @GetMapping
+    public ResponseForm<CommentPageResponse> get(@PathVariable("post-id") Long postId) {
+        return new ResponseForm<>(commentService.get(postId));
+    }
 
     @PostMapping
     public ResponseForm<CommentResponse> create(@PathVariable("post-id") Long postId,

--- a/src/main/java/com/tripmate/tripmate/post/domain/Comment.java
+++ b/src/main/java/com/tripmate/tripmate/post/domain/Comment.java
@@ -9,9 +9,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Getter
 @Builder
@@ -28,9 +25,6 @@ public class Comment extends BaseTimeEntity {
 
     @ManyToOne
     private Comment parentComment;
-
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> childComment = new ArrayList<>();
 
     @ManyToOne
     private User user;
@@ -50,10 +44,6 @@ public class Comment extends BaseTimeEntity {
         this.parentComment = parentComment;
     }
 
-    public void addCommentReply(Comment reply) {
-        this.childComment.add(reply);
-        reply.setParentComment(this);
-    }
 
     public void updateContents(String contents, User user) {
         if (!isOwner(user)) {
@@ -61,6 +51,7 @@ public class Comment extends BaseTimeEntity {
         }
         this.contents = contents;
     }
+
     public boolean isOwner(User user) {
         return this.user.equals(user);
     }

--- a/src/main/java/com/tripmate/tripmate/post/dto/response/CommentPageResponse.java
+++ b/src/main/java/com/tripmate/tripmate/post/dto/response/CommentPageResponse.java
@@ -1,0 +1,46 @@
+package com.tripmate.tripmate.post.dto.response;
+
+import com.tripmate.tripmate.post.domain.Comment;
+import lombok.Data;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Data
+public class CommentPageResponse {
+
+    private final Set<CommentResponse> commentResponses;
+
+    public static CommentPageResponse from(List<Comment> comments) {
+        Set<CommentResponse> commentResponseSet = organizeChildComments(comments.stream()
+                .map(CommentResponse::from)
+                .collect(Collectors.toSet()));
+
+        return new CommentPageResponse(
+                commentResponseSet
+        );
+    }
+
+    private static Set<CommentResponse> organizeChildComments(Set<CommentResponse> responses) {
+        Map<Long, CommentResponse> map = responses.stream()
+                .collect(Collectors.toMap(CommentResponse::getCommentId, Function.identity()));
+
+        map.values().stream()
+                .filter(CommentResponse::hasParentComment)
+                .forEach(comment -> {
+                    CommentResponse parentComment = map.get(comment.getParentCommentId());
+                    parentComment.getChildComments().add(comment);
+                });
+
+        return map.values().stream()
+                .filter(comment -> !comment.hasParentComment())
+                .collect(Collectors.toCollection(() ->
+                        new TreeSet<>(Comparator
+                                .comparing(CommentResponse::getCreatedAt)
+                                .reversed()
+                                .thenComparing(CommentResponse::getCommentId)
+                        )
+                ));
+    }
+}

--- a/src/main/java/com/tripmate/tripmate/post/dto/response/CommentResponse.java
+++ b/src/main/java/com/tripmate/tripmate/post/dto/response/CommentResponse.java
@@ -1,24 +1,46 @@
 package com.tripmate.tripmate.post.dto.response;
 
 import com.tripmate.tripmate.post.domain.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
 
-public record CommentResponse(
-        Long id,
-        String writer,
-        String contents,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
-) {
-    public static CommentResponse from(final Comment comment) {
+@Data
+@AllArgsConstructor
+public class CommentResponse {
+    private Long commentId;
+    private Long userId;
+    private Long parentCommentId;
+    private String contents;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Set<CommentResponse> childComments;
+
+    public static CommentResponse from(Comment comment) {
+        Comment parentComment = comment.getParentComment();
+
+        Set<CommentResponse> childComments = new TreeSet<>(Comparator
+                .comparing(CommentResponse::getCreatedAt)
+                .thenComparing(CommentResponse::getCommentId));
+
         return new CommentResponse(
                 comment.getId(),
-                comment.getUser().getName(),
+                comment.getUser().getId(),
+                parentComment != null ? parentComment.getId() : null,
                 comment.getContents(),
                 comment.getCreatedAt(),
-                comment.getUpdatedAt()
+                comment.getUpdatedAt(),
+                childComments
         );
     }
+
+    public boolean hasParentComment() {
+        return getParentCommentId() != null;
+    }
 }
+
 

--- a/src/main/java/com/tripmate/tripmate/post/repository/CommentRepository.java
+++ b/src/main/java/com/tripmate/tripmate/post/repository/CommentRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -14,4 +17,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         return findById(postCommentId)
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
     }
+
+    List<Comment> findAllByPostId(Long postId);
+
+    List<Comment> findAllByPostIdAndParentCommentIdIsNull(Long postId);
 }

--- a/src/main/java/com/tripmate/tripmate/post/service/CommentService.java
+++ b/src/main/java/com/tripmate/tripmate/post/service/CommentService.java
@@ -5,6 +5,7 @@ import com.tripmate.tripmate.common.ResultCode;
 import com.tripmate.tripmate.post.domain.Comment;
 import com.tripmate.tripmate.post.dto.request.CommentRequest;
 import com.tripmate.tripmate.post.dto.response.CommentResponse;
+import com.tripmate.tripmate.post.dto.response.CommentPageResponse;
 import com.tripmate.tripmate.post.repository.CommentRepository;
 import com.tripmate.tripmate.post.repository.PostRepository;
 import com.tripmate.tripmate.user.domain.User;
@@ -14,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -21,6 +24,12 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public CommentPageResponse get(Long postId) {
+        List<Comment> comments = commentRepository.findAllByPostId(postId);
+        return CommentPageResponse.from(comments);
+    }
 
     @Transactional
     public CommentResponse create(final Long userId,
@@ -32,7 +41,7 @@ public class CommentService {
 
         if (hasParentComment(request.parentCommentId())) {
             Comment parentComment = commentRepository.getById(request.parentCommentId());
-            parentComment.addCommentReply(comment);
+            parentComment.setParentComment(parentComment);
         }
 
         return CommentResponse.from(commentRepository.save(comment));

--- a/src/test/java/com/tripmate/tripmate/post/domain/CommentTest.java
+++ b/src/test/java/com/tripmate/tripmate/post/domain/CommentTest.java
@@ -47,7 +47,7 @@ class CommentTest {
 
         comment.addCommentReply(comment2);
 
-        Assertions.assertThat(comment.getChildComment()).contains(comment2);
+        Assertions.assertThat(comment.getChildComments()).contains(comment2);
         Assertions.assertThat(comment2.getParentComment()).isEqualTo(comment);
 
     }
@@ -62,7 +62,7 @@ class CommentTest {
         return Comment.builder()
                 .contents("test contents")
                 .user(user)
-                .childComment(new ArrayList<>())
+                .childComments(new ArrayList<>())
                 .build();
     }
 }

--- a/src/test/java/com/tripmate/tripmate/post/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/tripmate/tripmate/post/repository/CommentRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.tripmate.tripmate.post.repository;
+
+import com.tripmate.tripmate.post.domain.Comment;
+import com.tripmate.tripmate.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+class CommentRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    void testFindAllByPostIdAndParentCommentIdIsNull() {
+        // Setup data
+        Long postId = 1L;
+        User user = User.builder().name("test name").build(); // Assume User class is set up appropriately
+        entityManager.persist(user);
+
+        // Create a parent comment
+        Comment parentComment = new Comment(postId, user, "Parent comment");
+        entityManager.persist(parentComment);
+
+        // Create child comments
+        Comment childComment1 = new Comment(postId, user, "Child comment 1");
+        childComment1.setParentComment(parentComment);
+        entityManager.persist(childComment1);
+
+        // Create a top-level comment
+        Comment topLevelComment = new Comment(postId, user, "Top-level comment");
+        entityManager.persist(topLevelComment);
+
+        entityManager.flush();
+
+        // Test the method
+        List<Comment> results = commentRepository.findAllByPostIdAndParentCommentIdIsNull(postId);
+
+        // Verification
+        assertEquals(2, results.size()); // Should only find the top-level comment
+        assertEquals("Top-level comment", results.get(0).getContents());
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

> 특정 포스트 모든 댓글 조회 구현
쿼리dsl로 부모댓글,자식댓글 묶음을 가져오려고 했지만,
자식댓글의 자식댓글을 가져오게 하는 쿼리문을 어떻게 짜야 할지 몰라
해당 댓글을 모두 가져오고 dto 단에서 부모와 자식 댓글을 묶어줫습니다.
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

자식댓글의 자식댓글의 자식 댓글을 가져오게 하는 좋은 방법이 있으시다면 공유해주세요!
